### PR TITLE
Support raw_header setting, and version bump

### DIFF
--- a/lib/devise/jwt.rb
+++ b/lib/devise/jwt.rb
@@ -82,6 +82,10 @@ module Devise
             default: Warden::JWTAuth.config.jwks_url,
             constructor: ->(value) { forward_to_warden(:jwks_url, value)})
 
+    setting(:raw_header,
+            default: Warden::JWTAuth.config.raw_header,
+            constructor: ->(value) { forward_to_warden(:raw_header, value)})
+
     # A hash of warden scopes as keys and an array of request formats that will
     # be processed as values. When a scope is not present or if it has a nil
     # item, requests without format will be taken into account.

--- a/lib/devise/jwt/version.rb
+++ b/lib/devise/jwt/version.rb
@@ -2,6 +2,6 @@
 
 module Devise
   module JWT
-    VERSION = '0.13.1'
+    VERSION = '0.13.2'
   end
 end


### PR DESCRIPTION
We don't send `Bearer xxxx` on our JWT header, adding support